### PR TITLE
Added functionality to use https for backend routes. 

### DIFF
--- a/src/main/java/com/openshift/evg/roadshow/rest/RouteWatcher.java
+++ b/src/main/java/com/openshift/evg/roadshow/rest/RouteWatcher.java
@@ -37,7 +37,11 @@ public class RouteWatcher extends AbstractResourceWatcher<Route> {
     Route route = routes.get(0);
     String routeUrl = "";
     try {
-      routeUrl = "http://" + route.getSpec().getHost();
+      String protocol = "http://";
+      if((route.getSpec().getTls()!=null)&&(route.getSpec().getTls().getTermination()!=null)){
+        protocol = "https://";
+      }
+      routeUrl = protocol + route.getSpec().getHost();
     } catch (Exception e) {
       logger.error("Route {} does not have a port assigned", routeName);
     }

--- a/src/main/java/com/openshift/evg/roadshow/rest/gateway/CustomFeignClient.java
+++ b/src/main/java/com/openshift/evg/roadshow/rest/gateway/CustomFeignClient.java
@@ -1,0 +1,64 @@
+package com.openshift.evg.roadshow.rest.gateway;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.X509Certificate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+
+import feign.Client;
+
+class CustomFeignClient {
+  private static final Logger logger = LoggerFactory.getLogger(CustomFeignClient.class);
+    /**
+   * This method should not be used in production!! It is only in a poof of
+   * concept!
+   * 
+   * @return
+   */
+  private static SSLSocketFactory getSSLSocketFactory() {
+    try {
+      SSLContext context = SSLContext.getInstance("TLS");
+      context.init(null, new X509TrustManager[] { new X509TrustManager() {
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+          logger.info("checkClientTrusted");
+        }
+
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+          logger.info("checkClientTrusted");
+        }
+
+        public X509Certificate[] getAcceptedIssuers() {
+          logger.info("checkClientTrusted");
+          return new X509Certificate[0];
+        }
+      } }, new SecureRandom());
+      logger.warn("Ignoring certification errors! Don't use in production!");
+      return context.getSocketFactory();
+    } catch (Exception exception) {
+      throw new RuntimeException(exception);
+    }
+  }
+
+  public static Client getClient() {
+    return new Client.Default(getSSLSocketFactory(), getHostNameVerifier());
+  }
+
+  private static HostnameVerifier getHostNameVerifier() {
+    HostnameVerifier hostnameVerifier= new HostnameVerifier(){
+
+      public boolean verify(String hostname,
+              javax.net.ssl.SSLSession sslSession) {
+                logger.warn("Ignoring hostname verification errors! Don't use in production!");
+          return true;
+      }
+    };
+    return hostnameVerifier;
+  }
+}

--- a/src/main/java/com/openshift/evg/roadshow/rest/gateway/DataGatewayController.java
+++ b/src/main/java/com/openshift/evg/roadshow/rest/gateway/DataGatewayController.java
@@ -37,7 +37,7 @@ public class DataGatewayController {
    */
   public final void add(String backendId, String url) {
     if (remoteServices.get(backendId) == null) {
-      remoteServices.put(backendId, Feign.builder().contract(new JAXRSContract()).encoder(new JacksonEncoder())
+      remoteServices.put(backendId, Feign.builder().client(CustomFeignClient.getClient()).contract(new JAXRSContract()).encoder(new JacksonEncoder())
           .decoder(new JacksonDecoder()).target(DataServiceRemote.class, url));
       logger.info("Backend ({}) added to the Data Gateway", backendId);
     } else {


### PR DESCRIPTION
So far the backend routes in the parksmap application could only use HTTP and not HTTPS. I added code to check for the protocol in the RouteWatcher whether the route is using http or https. To avoid error messages that the certificate of the backend route can not be trusted (i.e. the signer is unknown), I added a class that will skip the SSL and host name verification.