### PR TITLE
Fixed the mixed content error message

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -4,7 +4,7 @@
 	<title>Map Visualizer on OpenShift 4</title>
 	<link rel="stylesheet" href="leaflet/leaflet.css"/>
 	<link rel="stylesheet" href="parksmap.css"/>
-	<link href='https://fonts.googleapis.com/css?family=Oswald' rel='stylesheet' type='text/css'>
+	<link href="//fonts.googleapis.com/css?family=Oswald" rel="stylesheet" type="text/css">
 	<link rel="stylesheet" href="leaflet/markercluster/MarkerCluster.css"/>
 	<link rel="stylesheet" href="leaflet/markercluster/MarkerCluster.Default.css"/>
 	<link rel="stylesheet" href="leaflet/font-awesome.min.css">


### PR DESCRIPTION
There was an error message in the console about mixed content being used. That's because the Google fonts URL used was specifically requesting https but the cluster might be running on a non-secure route. Using "//" instead of the protocol will actually use same protocol as the index.html page.